### PR TITLE
Implement tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ services:
       - '6969:6969'
     environment:
       GODMODE: admin
+      TABS: Safest,Nordamed
     restart: always
     volumes:
       - /mnt/user/appdata/pluginregistrationapp:/opt/pluginregistrationapp/data

--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ To test the production build, run
 docker compose -f docker-compose-production.yml up --build
 ```
 
+## Environment Variables
+
+| Name               | Used by                                | Required          | Example                 | Description                                                                                    |
+| ------------------ | -------------------------------------- | ----------------- | ----------------------- | ---------------------------------------------------------------------------------------------- |
+| `GODMODE`          | Server (`backend`)                     | Yes               | `admin`                 | Password that allows privileged queue removal (`godmodePassword`).                             |
+| `TABS`             | Server (`backend`)                     | Yes               | `Safest,Nordamed`       | Comma-separated tab labels. These are normalized to lowercase IDs and exposed via `GET /tabs`. |
+| `VITE_BACKEND_URL` | Client (`frontend`)                    | Yes               | `http://localhost:6969` | Base URL used by the web app for REST + Socket.IO calls.                                       |
+| `BACKEND_URL`      | Docker build arg (`client.dockerfile`) | For Docker builds | `http://localhost:6969` | Build-time value mapped to `VITE_BACKEND_URL` in the client image.                             |
+
 ## Docker Compose Example
 
 ```yaml

--- a/client/.env
+++ b/client/.env
@@ -1,1 +1,2 @@
 VITE_BACKEND_URL=http://localhost:6969
+

--- a/client/.env
+++ b/client/.env
@@ -1,2 +1,0 @@
-VITE_BACKEND_URL=http://localhost:6969
-

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -28,6 +28,7 @@ import check from './icons/check.svg'
 import cross from './icons/cross.svg'
 
 let counter = 0
+const LAST_ACTIVE_TAB_STORAGE_KEY = 'lastActiveTab'
 
 export default function App() {
   const [tabs, setTabs] = useState<TabConfig[]>([])
@@ -69,7 +70,22 @@ export default function App() {
       try {
         const configuredTabs = await apiGetTabs()
         setTabs(configuredTabs)
-        setActiveTab(configuredTabs[0]?.id)
+        const availableTabIds = new Set(configuredTabs.map(tab => tab.id))
+        const tabFromUrl = new URLSearchParams(globalThis.location.search).get('tab')
+        const storedTab = localStorage.getItem(LAST_ACTIVE_TAB_STORAGE_KEY)
+        const preferredTab =
+          (tabFromUrl && availableTabIds.has(tabFromUrl) && tabFromUrl) ||
+          (storedTab && availableTabIds.has(storedTab) && storedTab) ||
+          configuredTabs[0]?.id
+
+        setActiveTab(preferredTab)
+
+        if (!preferredTab) return
+        const url = new URL(globalThis.location.href)
+        if (url.searchParams.get('tab') !== preferredTab) {
+          url.searchParams.set('tab', preferredTab)
+          globalThis.history.replaceState(null, '', url.toString())
+        }
       } catch (err) {
         console.error('Failed to load tabs:', err)
         setDisplaySpinner(false)
@@ -79,6 +95,15 @@ export default function App() {
 
     loadTabs()
   }, [])
+
+  useEffect(() => {
+    if (!activeTab) return
+    localStorage.setItem(LAST_ACTIVE_TAB_STORAGE_KEY, activeTab)
+    const url = new URL(globalThis.location.href)
+    if (url.searchParams.get('tab') === activeTab) return
+    url.searchParams.set('tab', activeTab)
+    globalThis.history.replaceState(null, '', url.toString())
+  }, [activeTab])
 
   useEffect(() => {
     if (!activeTab) return

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,7 @@ import {
   getTabs as apiGetTabs,
   registerIdentity,
   removeFromQueue as apiRemoveFromQueue,
+  switchSocketTab,
   TabConfig,
 } from './api/queueApi'
 import { playAudio } from './utils/audio'
@@ -84,7 +85,8 @@ export default function App() {
     setDisplaySpinner(true)
     setDisplayModal(false)
     currentHolderRef.current = undefined
-    const socket = getSocket(activeTab)
+    const socket = getSocket()
+    switchSocketTab(activeTab)
     const handleStateUpdate = (newState: QueueEntry[]) => {
       const newHolder = newState.find(entry => isCurrent(entry))
       const soundToPlay = getSoundToPlayForStateUpdate(

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -124,7 +124,7 @@ export default function App() {
   }
 
   const removeFromQueue = async (user: QueueEntry) => {
-    if (!activeTab) return
+    if (!activeTab) throw new Error('Mangler aktiv fane for å fjerne deg fra køen')
     currentHolderRef.current = undefined
     if (!identity?.privateKey) throw new Error('Du må være logget inn for å forlate køen')
 
@@ -148,8 +148,12 @@ export default function App() {
   }
 
   function closeExitModal(userDidConfirm: boolean) {
-    if (userDidConfirm) {
-      if (modalEntry) removeFromQueue(modalEntry)
+    if (userDidConfirm && modalEntry) {
+      void removeFromQueue(modalEntry).catch(err => {
+        const message = err instanceof Error ? err.message : 'Kunne ikke fjerne deg fra køen'
+        alert(message)
+        console.error(message, err)
+      })
     }
     setDisplayModal(false)
     setModalEntry(null)

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,7 +1,13 @@
 import { FormEvent, useEffect, useRef, useState } from 'react'
 import { isCurrent, isPending, QueueEntry, QueueEntryCurrent } from '../../models/QueueEntry'
 import { AudioMode, defaultSettings, UserSettings } from '../../models/UserSettings'
-import { addToQueue as apiAddToQueue, getSocket, removeFromQueue as apiRemoveFromQueue } from './api/queueApi'
+import {
+  addToQueue as apiAddToQueue,
+  getSocket,
+  getTabs as apiGetTabs,
+  removeFromQueue as apiRemoveFromQueue,
+  TabConfig,
+} from './api/queueApi'
 import { playAudio } from './utils/audio'
 import { getPrivateKey } from './utils/privateKey'
 import { loadUserSettingsFromStorage, saveUserSettingsToStorage } from './utils/settings'
@@ -22,6 +28,8 @@ import cross from './icons/cross.svg'
 let counter = 0
 
 export default function App() {
+  const [tabs, setTabs] = useState<TabConfig[]>([])
+  const [activeTab, setActiveTab] = useState<string>()
   const [data, setData] = useState(new Array<QueueEntry>())
   const [displayModal, setDisplayModal] = useState(false)
   const [currentModalUserIndex, setCurrentModalUserIndex] = useState(0)
@@ -52,8 +60,28 @@ export default function App() {
   }, [appSettings])
 
   useEffect(() => {
-    const socket = getSocket()
-    socket.on('stateUpdate', (newState: QueueEntry[]) => {
+    const loadTabs = async () => {
+      try {
+        const configuredTabs = await apiGetTabs()
+        setTabs(configuredTabs)
+        setActiveTab(configuredTabs[0]?.id)
+      } catch (err) {
+        console.error('Failed to load tabs:', err)
+        setDisplaySpinner(false)
+        alert('Kunne ikke hente faner fra serveren')
+      }
+    }
+
+    loadTabs()
+  }, [])
+
+  useEffect(() => {
+    if (!activeTab) return
+    setDisplaySpinner(true)
+    setDisplayModal(false)
+    currentHolderRef.current = undefined
+    const socket = getSocket(activeTab)
+    const handleStateUpdate = (newState: QueueEntry[]) => {
       const newHolder = newState.find(entry => isCurrent(entry))
       const soundToPlay = getSoundToPlayForStateUpdate(
         currentHolderRef.current,
@@ -68,11 +96,13 @@ export default function App() {
       currentHolderRef.current = newHolder
       setData(newState)
       setDisplaySpinner(false)
-    })
-    return () => {
-      socket.off('stateUpdate')
     }
-  }, [])
+
+    socket.on('stateUpdate', handleStateUpdate)
+    return () => {
+      socket.off('stateUpdate', handleStateUpdate)
+    }
+  }, [activeTab])
 
   useEffect(() => {
     const stored = loadUserSettingsFromStorage()
@@ -85,12 +115,14 @@ export default function App() {
   }, [])
 
   const addToQueue = (queueEntry: QueueEntry) => {
-    apiAddToQueue(queueEntry)
+    if (!activeTab) return
+    apiAddToQueue(queueEntry, activeTab)
   }
 
   const removeFromQueue = async (user: QueueEntry) => {
+    if (!activeTab) return
     currentHolderRef.current = undefined
-    await apiRemoveFromQueue(user, getPrivateKey(), appSettingsRef.current.godmodePassword)
+    await apiRemoveFromQueue(user, getPrivateKey(), appSettingsRef.current.godmodePassword, activeTab)
   }
 
   const nameInputRef = useRef<HTMLInputElement>(null)
@@ -113,7 +145,7 @@ export default function App() {
     const nameInput = nameInputRef.current?.value
     const timeInput = timeInputRef.current?.value
 
-    if (!nameInput || nameInput.length === 0) return
+    if (!activeTab || !nameInput || nameInput.length === 0) return
 
     addToQueue({
       id: getPrivateKey(),
@@ -145,6 +177,20 @@ export default function App() {
         handleOption={setOptions}
         userAppSettings={appSettings}
       />
+      {tabs.length > 0 && (
+        <div className='tabRow'>
+          {tabs.map(tab => (
+            <button
+              key={tab.id}
+              className={`tabButton ${tab.id === activeTab ? 'activeTab' : ''}`}
+              onClick={() => setActiveTab(tab.id)}
+              type='button'
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+      )}
       <div className='banner'>Er Plugin Registration ledig?</div>
       {displaySpinner ? (
         <Spinner />
@@ -188,7 +234,10 @@ export default function App() {
         )}
       </form>
       {displayModal && (
-        <ExitModal displayItem={queue[currentModalUserIndex].username} closeModalFunction={closeExitModal} />
+        <ExitModal
+          displayItem={queue[currentModalUserIndex]?.username ?? ''}
+          closeModalFunction={closeExitModal}
+        />
       )}
 
       {!appSettings['hideLog'] && <HistoryDisplay data={data} />}

--- a/client/src/api/queueApi.ts
+++ b/client/src/api/queueApi.ts
@@ -25,15 +25,20 @@ function ensureAxiosBaseUrl(): void {
   }
 }
 
-export function getSocket(tabId: string): Socket {
+export function getSocket(): Socket {
   ensureAxiosBaseUrl()
-  if (!socketInstance || socketTabId !== tabId) {
-    socketInstance?.disconnect()
+  if (!socketInstance) {
     const adr = getBackendUrl()
-    socketInstance = io(adr, { transports: ['websocket'], query: { tab: tabId } })
-    socketTabId = tabId
+    socketInstance = io(adr, { transports: ['websocket'] })
   }
   return socketInstance
+}
+
+export function switchSocketTab(tabId: string): void {
+  const socket = getSocket()
+  if (socketTabId === tabId) return
+  socket.emit('switchTab', tabId)
+  socketTabId = tabId
 }
 
 export async function getTabs(): Promise<TabConfig[]> {

--- a/client/src/api/queueApi.ts
+++ b/client/src/api/queueApi.ts
@@ -3,7 +3,13 @@ import io, { type Socket } from 'socket.io-client'
 import type { QueueEntry } from '../../../models/QueueEntry'
 import { timestamp } from '../utils/logger'
 
+export type TabConfig = {
+  id: string
+  label: string
+}
+
 let socketInstance: Socket | null = null
+let socketTabId: string | null = null
 
 export function getBackendUrl(): string {
   const adr = import.meta.env.VITE_BACKEND_URL
@@ -19,21 +25,30 @@ function ensureAxiosBaseUrl(): void {
   }
 }
 
-export function getSocket(): Socket {
+export function getSocket(tabId: string): Socket {
   ensureAxiosBaseUrl()
-  if (!socketInstance) {
+  if (!socketInstance || socketTabId !== tabId) {
+    socketInstance?.disconnect()
     const adr = getBackendUrl()
-    socketInstance = io(adr, { transports: ['websocket'] })
+    socketInstance = io(adr, { transports: ['websocket'], query: { tab: tabId } })
+    socketTabId = tabId
   }
   return socketInstance
 }
 
-export async function addToQueue(queueEntry: QueueEntry): Promise<void> {
+export async function getTabs(): Promise<TabConfig[]> {
   ensureAxiosBaseUrl()
   const adr = getBackendUrl()
-  console.log(timestamp(), 'Adding ' + queueEntry.username + ' to queue')
+  const response = await axios.get<TabConfig[]>(adr + '/tabs')
+  return response.data
+}
+
+export async function addToQueue(queueEntry: QueueEntry, tab: string): Promise<void> {
+  ensureAxiosBaseUrl()
+  const adr = getBackendUrl()
+  console.log(timestamp(), `Adding ${queueEntry.username} to queue '${tab}'`)
   try {
-    await axios.post(adr + '/add', { value: queueEntry })
+    await axios.post(adr + '/add', { value: queueEntry, tab })
   } catch (e) {
     console.warn(timestamp(), e)
     const message = e && typeof e === 'object' && 'response' in e && e.response && typeof e.response === 'object' && 'data' in e.response ? (e.response as { data: unknown }).data : 'Request failed'
@@ -44,16 +59,18 @@ export async function addToQueue(queueEntry: QueueEntry): Promise<void> {
 export async function removeFromQueue(
   user: QueueEntry,
   privateKey: string,
-  godmodePassword: string
+  godmodePassword: string,
+  tab: string
 ): Promise<void> {
   ensureAxiosBaseUrl()
   const adr = getBackendUrl()
-  console.log(timestamp(), 'Removing ' + user.username + ' from queue')
+  console.log(timestamp(), `Removing ${user.username} from queue '${tab}'`)
   try {
     await axios.post(adr + '/remove', {
       value: user,
       privateKey,
       godmodePassword,
+      tab,
     })
   } catch (e) {
     if (!(e instanceof AxiosError)) throw e

--- a/client/src/styles/App.css
+++ b/client/src/styles/App.css
@@ -14,8 +14,35 @@ body {
   align-items: center;
 }
 
-.banner {
+.tabRow {
+  display: flex;
+  gap: 0.5em;
   margin-top: 1em;
+  margin-bottom: 0.5em;
+}
+
+.tabButton {
+  border: 1px solid #7fbab7;
+  background: transparent;
+  color: #cde8e6;
+  padding: 0.4em 0.9em;
+  border-radius: 999px;
+  cursor: pointer;
+  font-size: 0.95rem;
+}
+
+.tabButton:hover {
+  background: #0f4f4c;
+}
+
+.activeTab {
+  background: #126662;
+  color: white;
+  border-color: #126662;
+}
+
+.banner {
+  margin-top: 0.5em;
   color: rgb(255, 255, 255);
   font-family: Lato, sans-serif;
   font-size: 3vw;

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -17,6 +17,7 @@ services:
       - '6969:6969'
     environment:
       GODMODE: admin
+      TABS: Safest,Nordamed
     restart: always
     volumes:
       - ./data:/opt/pluginregistrationapp/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
       - '6969:6969'
     environment:
       GODMODE: admin
+      TABS: Safest,Nordamed
     restart: always
     volumes:
       - ./data:/opt/pluginregistrationapp/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       - '6969:6969'
     environment:
       GODMODE: admin
-      TABS: Safest,Nordamed
+      TABS: DELE,Safest,Nordamed
     restart: always
     volumes:
       - ./data:/opt/pluginregistrationapp/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,9 +18,11 @@ services:
         - action: rebuild
           path: ./client-dev.dockerfile
         - action: rebuild
+          path: ./docker-compose.yml
+        - action: rebuild
           path: ./client/*.{js,ts,json}
     ports:
-      - '5173:5173'
+      - "5173:5173"
     restart: always
 
   backend:
@@ -38,7 +40,7 @@ services:
           path: ./models
           target: /opt/pluginregistrationapp/models
     ports:
-      - '6969:6969'
+      - "6969:6969"
     environment:
       GODMODE: admin
       TABS: DELE,Safest,Nordamed

--- a/server/backend.ts
+++ b/server/backend.ts
@@ -109,15 +109,28 @@ app.post('/remove', (req: Request, res: Response) => {
 
 io.on('connection', socket => {
   console.debug(timestamp(), 'Connected', socket.id)
-  const tabId = normalizeTabId(socket.handshake.query.tab)
-  if (!tabId) {
-    socket.emit('error', 'Missing or invalid tab')
-    socket.disconnect()
-    return
+  let activeTabId: string | null = null
+
+  const switchTab = (rawTabId: unknown) => {
+    const tabId = normalizeTabId(rawTabId)
+    if (!tabId) {
+      socket.emit('error', 'Missing or invalid tab')
+      return
+    }
+    if (activeTabId === tabId) return
+
+    if (activeTabId) {
+      socket.leave(activeTabId)
+    }
+    activeTabId = tabId
+    socket.join(tabId)
+    socket.emit('stateUpdate', loadData(tabId)) // Send tab state to socket after room switch
   }
 
-  socket.join(tabId)
-  socket.emit('stateUpdate', loadData(tabId)) // Send tab state to newly connected client
+  // Keep compatibility with older clients that still pass `tab` on handshake.
+  switchTab(socket.handshake.query.tab)
+
+  socket.on('switchTab', switchTab)
 
   socket.on('disconnect', () => {
     console.debug(timestamp(), 'Disconnected', socket.id)

--- a/server/backend.ts
+++ b/server/backend.ts
@@ -4,9 +4,48 @@ import { createServer } from 'node:http'
 import { Server } from 'socket.io'
 import { enterQueue, exitQueue, loadData, removeOldEntries } from './dataService.ts'
 import process from 'node:process'
+import { QueueEntry } from '../models/QueueEntry.ts'
 
 const correctGodmodePassword = process.env.GODMODE
 if (!correctGodmodePassword) throw new Error('GODMODE environment variable not set')
+
+type TabConfig = {
+  id: string
+  label: string
+}
+
+function parseTabsEnv(rawTabs: string | undefined): TabConfig[] {
+  if (!rawTabs) throw new Error('TABS environment variable not set')
+
+  const tabMap = new Map<string, TabConfig>()
+  for (const rawLabel of rawTabs.split(',')) {
+    const label = rawLabel.trim()
+    if (!label) continue
+    const id = label.toLowerCase()
+    if (!tabMap.has(id)) {
+      tabMap.set(id, { id, label })
+    }
+  }
+
+  const tabs = Array.from(tabMap.values())
+  if (tabs.length === 0) throw new Error('TABS environment variable does not contain any valid tab labels')
+  return tabs
+}
+
+const tabs = parseTabsEnv(process.env.TABS)
+const tabIds = new Set(tabs.map(tab => tab.id))
+
+function normalizeTabId(input: unknown): string | null {
+  if (typeof input !== 'string') return null
+  const tabId = input.trim().toLowerCase()
+  return tabIds.has(tabId) ? tabId : null
+}
+
+function getTabIdFromBody(req: Request): string {
+  const tabId = normalizeTabId(req.body?.tab)
+  if (!tabId) throw new Error('Missing or invalid tab')
+  return tabId
+}
 
 const app: Express = express()
 const server = createServer(app)
@@ -20,11 +59,16 @@ app.options('*', cors()) // Enable pre-flight across-the-board
 
 const timestamp = () => new Date().toISOString()
 
+app.get('/tabs', (_req: Request, res: Response) => {
+  res.status(200).json(tabs)
+})
+
 // API to append the queue
 app.post('/add', (req: Request, res: Response) => {
   try {
-    const updatedQueue = enterQueue(req.body.value)
-    io.emit('stateUpdate', updatedQueue) // Broadcast the updated state to all clients
+    const tabId = getTabIdFromBody(req)
+    const updatedQueue = enterQueue(tabId, req.body.value as QueueEntry)
+    io.to(tabId).emit('stateUpdate', updatedQueue) // Broadcast only within tab room
     res.sendStatus(200)
   } catch (err) {
     if (!(err instanceof Error)) throw err
@@ -36,11 +80,12 @@ app.post('/add', (req: Request, res: Response) => {
 // API to remove from the queue
 app.post('/remove', (req: Request, res: Response) => {
   try {
+    const tabId = getTabIdFromBody(req)
     const { value, privateKey, godmodePassword } = req.body
     console.debug(timestamp(), 'Received remove request:', req.body)
 
-    const updatedQueue = exitQueue(value, privateKey, godmodePassword === correctGodmodePassword)
-    io.emit('stateUpdate', updatedQueue) // Broadcast the updated state to all clients
+    const updatedQueue = exitQueue(tabId, value as QueueEntry, privateKey, godmodePassword === correctGodmodePassword)
+    io.to(tabId).emit('stateUpdate', updatedQueue) // Broadcast only within tab room
     res.sendStatus(200)
   } catch (err) {
     if (!(err instanceof Error)) throw err
@@ -51,7 +96,16 @@ app.post('/remove', (req: Request, res: Response) => {
 
 io.on('connection', socket => {
   console.debug(timestamp(), 'Connected', socket.id)
-  socket.emit('stateUpdate', loadData()) // Send the current state to newly connected client
+  const tabId = normalizeTabId(socket.handshake.query.tab)
+  if (!tabId) {
+    socket.emit('error', 'Missing or invalid tab')
+    socket.disconnect()
+    return
+  }
+
+  socket.join(tabId)
+  socket.emit('stateUpdate', loadData(tabId)) // Send tab state to newly connected client
+
   socket.on('disconnect', () => {
     console.debug(timestamp(), 'Disconnected', socket.id)
   })
@@ -64,11 +118,16 @@ server.listen(port, () => {
   setInterval(() => {
     console.debug(timestamp(), 'Checking for old entries')
 
-    const newState = removeOldEntries()
-    if (newState) {
-      console.debug(timestamp(), 'Removed entries, broadcasting new state')
-      io.emit('stateUpdate', newState)
-    } else {
+    let didRemoveAny = false
+    for (const tab of tabs) {
+      const newState = removeOldEntries(tab.id)
+      if (!newState) continue
+      didRemoveAny = true
+      console.debug(timestamp(), `Removed entries, broadcasting new state for tab '${tab.id}'`)
+      io.to(tab.id).emit('stateUpdate', newState)
+    }
+
+    if (!didRemoveAny) {
       console.debug(timestamp(), 'No entries were removed')
     }
   }, 1000 * 60)

--- a/server/dataService.ts
+++ b/server/dataService.ts
@@ -43,7 +43,7 @@ export function exitQueue(tabId: string, toRemove: QueueEntry, privateKey: strin
 
   // Get the index of the entry to remove
   const i = data.findIndex(entry => isSame(entry, toRemove) && isPending(entry))
-  if (i === null) throw new Error(`Brukeren '${toRemove.username}' ble ikke funnet i køen`)
+  if (i === -1) throw new Error(`Brukeren '${toRemove.username}' ble ikke funnet i køen`)
 
   let item = data[i]
 

--- a/server/dataService.ts
+++ b/server/dataService.ts
@@ -2,25 +2,30 @@ import { readFileSync, writeFileSync } from 'node:fs'
 import { isCurrent, isExited, isPending, isSame, QueueEntry } from '../models/QueueEntry.ts'
 
 const timestamp = () => new Date().toISOString()
-const DATA_FILE = '../data/data.json'
+const DATA_FILE_DIR = '../data'
 
-export function loadData(): QueueEntry[] {
+function getDataFile(tabId: string): string {
+  return `${DATA_FILE_DIR}/${tabId}.json`
+}
+
+export function loadData(tabId: string): QueueEntry[] {
+  const dataFile = getDataFile(tabId)
   try {
-    const rawData = readFileSync(DATA_FILE)
+    const rawData = readFileSync(dataFile)
     return JSON.parse(rawData.toString())
   } catch (_) {
-    console.log(timestamp(), 'Initializing data file')
-    writeFileSync(DATA_FILE, '[]', { flag: 'w' })
+    console.log(timestamp(), `Initializing data file for '${tabId}'`)
+    writeFileSync(dataFile, '[]', { flag: 'w' })
     return []
   }
 }
 
-function saveData(data: QueueEntry[]) {
-  writeFileSync(DATA_FILE, JSON.stringify(data), { flag: 'w' })
+function saveData(tabId: string, data: QueueEntry[]) {
+  writeFileSync(getDataFile(tabId), JSON.stringify(data), { flag: 'w' })
 }
 
-export function enterQueue(entry: QueueEntry) {
-  const data = loadData()
+export function enterQueue(tabId: string, entry: QueueEntry) {
+  const data = loadData(tabId)
   const queue = data.filter(e => !e.exited)
 
   if (queue.length >= 5) throw new Error('Køen er full')
@@ -28,13 +33,13 @@ export function enterQueue(entry: QueueEntry) {
 
   data.push(entry)
 
-  saveData(data)
-  console.log(timestamp(), 'Added ' + entry.username + ' to queue')
+  saveData(tabId, data)
+  console.log(timestamp(), `Added ${entry.username} to queue '${tabId}'`)
   return data
 }
 
-export function exitQueue(toRemove: QueueEntry, privateKey: string | undefined, force = false) {
-  const data = loadData()
+export function exitQueue(tabId: string, toRemove: QueueEntry, privateKey: string | undefined, force = false) {
+  const data = loadData(tabId)
 
   // Get the index of the entry to remove
   const i = data.findIndex(entry => isSame(entry, toRemove) && isPending(entry))
@@ -58,20 +63,20 @@ export function exitQueue(toRemove: QueueEntry, privateKey: string | undefined, 
     console.debug(timestamp(), 'Updated next item:', data[indexOfNext])
   }
 
-  saveData(data)
-  console.log(new Date(item.exited).toISOString(), 'Removed ' + toRemove.username + ' from queue')
+  saveData(tabId, data)
+  console.log(new Date(item.exited).toISOString(), `Removed ${toRemove.username} from queue '${tabId}'`)
   return data
 }
 
-export function removeOldEntries() {
+export function removeOldEntries(tabId: string) {
   let didKick = false
-  loadData().forEach(entry => {
+  loadData(tabId).forEach(entry => {
     if (!isCurrent(entry)) return
     const kickTime = entry.entered + entry.estimated * 60 * 60 * 1000
     if (kickTime < Date.now()) {
       try {
         console.debug(timestamp(), 'Auto-kicking', entry.username)
-        exitQueue(entry, undefined, true)
+        exitQueue(tabId, entry, undefined, true)
         didKick = true
       } catch (err) {
         if (!(err instanceof Error)) throw err
@@ -80,5 +85,5 @@ export function removeOldEntries() {
     }
   })
 
-  return didKick ? loadData() : undefined
+  return didKick ? loadData(tabId) : undefined
 }


### PR DESCRIPTION
## Summary

- Add tab-scoped queues end-to-end: parse `TABS`, expose `GET /tabs`, validate tab IDs, scope queue operations per tab, and broadcast Socket.IO updates per tab room.
- Integrate identity-based auth flow: add `/register`, persist identity in client storage, support legacy private-key entries, and keep self-removal authorization working.
- Improve tab UX and realtime behavior: support tab deep links via `?tab=...`, persist last active tab in `localStorage`, and switch tabs over a single websocket connection (no reconnect on tab switch).
- Documentation update: add an environment variables table in `README.md` (`GODMODE`, `TABS`, `VITE_BACKEND_URL`, `BACKEND_URL`).

## Test plan

- [x] `npm run build` in `client/`
- [x] `npx -y react-doctor@latest . --verbose --diff`
- [x] Resolve merge conflicts from `main` and verify app compiles/lints after merge
- [x] Start backend with `GODMODE` and `TABS`, verify `GET /tabs` returns expected `{ id, label }[]`
- [x] Open app with and without `?tab=` and verify URL + localStorage tab selection behavior
- [x] Verify switching tabs does not create a new websocket connection, but state updates still follow selected tab
- [x] Verify users can join/leave queue (including legacy entry compatibility)
- [x] Verify tab isolation in data files (`data/<tab>.json`) and socket updates

Closes #51.