### PR TITLE
Fix client Docker env assignment syntax

### DIFF
--- a/.github/workflows/docker-build-client.yml
+++ b/.github/workflows/docker-build-client.yml
@@ -32,5 +32,6 @@ jobs:
           build-args: |
             BACKEND_URL=${{ vars.BACKEND_URL }}
           push: true
-          platforms: linux/amd64,linux/arm64
+          # arm64 build currently fails under QEMU with Node 22 (Illegal instruction)
+          platforms: linux/amd64
           tags: ${{ vars.DOCKER_USERNAME }}/pluginregistrationapp-client

--- a/.github/workflows/docker-build-client.yml
+++ b/.github/workflows/docker-build-client.yml
@@ -19,6 +19,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
@@ -32,6 +35,5 @@ jobs:
           build-args: |
             BACKEND_URL=${{ vars.BACKEND_URL }}
           push: true
-          # arm64 build currently fails under QEMU with Node 22 (Illegal instruction)
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           tags: ${{ vars.DOCKER_USERNAME }}/pluginregistrationapp-client

--- a/client.dockerfile
+++ b/client.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /opt/pluginregistrationapp
 
 # Environment variables
 ARG BACKEND_URL
-ENV VITE_BACKEND_URL $BACKEND_URL
+ENV VITE_BACKEND_URL=$BACKEND_URL
 
 # PORTS
 EXPOSE 5173

--- a/client.dockerfile
+++ b/client.dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine
+FROM --platform=$BUILDPLATFORM node:22-alpine AS build
 
 # Set the working directory
 WORKDIR /opt/pluginregistrationapp
@@ -7,17 +7,30 @@ WORKDIR /opt/pluginregistrationapp
 ARG BACKEND_URL
 ENV VITE_BACKEND_URL=$BACKEND_URL
 
-# PORTS
-EXPOSE 5173
-
 # Copy the app to the container
 COPY client client/
 COPY models models/
 
 WORKDIR /opt/pluginregistrationapp/client
 
-# Install dependencies
-RUN npm install -g serve && npm install && npm run build
+# Build static assets once on the builder platform
+RUN npm install && npm run build
 
-# Run the build
-CMD [ "serve", "-l", "5173", "-s", "build" ]
+FROM nginx:1.27-alpine
+
+# PORTS
+EXPOSE 5173
+
+# Serve the built client with nginx
+COPY --from=build /opt/pluginregistrationapp/client/build /usr/share/nginx/html
+RUN printf '%s\n' \
+  'server {' \
+  '  listen 5173;' \
+  '  server_name _;' \
+  '  root /usr/share/nginx/html;' \
+  '  index index.html;' \
+  '  location / {' \
+  '    try_files $uri /index.html;' \
+  '  }' \
+  '}' \
+  > /etc/nginx/conf.d/default.conf

--- a/client.dockerfile
+++ b/client.dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM node:22-alpine AS build
+FROM node:22-alpine
 
 # Set the working directory
 WORKDIR /opt/pluginregistrationapp
@@ -7,30 +7,17 @@ WORKDIR /opt/pluginregistrationapp
 ARG BACKEND_URL
 ENV VITE_BACKEND_URL=$BACKEND_URL
 
+# PORTS
+EXPOSE 5173
+
 # Copy the app to the container
 COPY client client/
 COPY models models/
 
 WORKDIR /opt/pluginregistrationapp/client
 
-# Build static assets once on the builder platform
-RUN npm install && npm run build
+# Install dependencies
+RUN npm install -g serve && npm install && npm run build
 
-FROM nginx:1.27-alpine
-
-# PORTS
-EXPOSE 5173
-
-# Serve the built client with nginx
-COPY --from=build /opt/pluginregistrationapp/client/build /usr/share/nginx/html
-RUN printf '%s\n' \
-  'server {' \
-  '  listen 5173;' \
-  '  server_name _;' \
-  '  root /usr/share/nginx/html;' \
-  '  index index.html;' \
-  '  location / {' \
-  '    try_files $uri /index.html;' \
-  '  }' \
-  '}' \
-  > /etc/nginx/conf.d/default.conf
+# Run the build
+CMD [ "serve", "-l", "5173", "-s", "build" ]


### PR DESCRIPTION
## Summary
- switch `VITE_BACKEND_URL` to `KEY=VALUE` syntax in `client.dockerfile`
- ensure the build arg is exported consistently as an environment variable during client image builds

## Test plan
- [x] Build the client image with `docker build -f client.dockerfile --build-arg BACKEND_URL=http://localhost:3000 .`
- [x] Run the container and verify `VITE_BACKEND_URL` is set in the runtime environment