### PR TITLE
Uptime i18n and today expected-count fix

### DIFF
--- a/client/src/UptimeDisplay.tsx
+++ b/client/src/UptimeDisplay.tsx
@@ -1,16 +1,19 @@
 import './styles/UptimeDisplay.css'
 import { UptimeSummary } from './api/queueApi'
+import useLanguage from './context/useLanguage'
 
 type Props = {
   uptime: UptimeSummary
 }
 
 export default function UptimeDisplay({ uptime }: Readonly<Props>) {
+  const t = useLanguage()
+
   return (
     <div className='uptimeDock'>
       
       <div className='uptimeHeader'>
-        <span className='uptimePercentage'>{uptime.uptimePercentage.toFixed(1)}% oppetid</span>
+        <span className='uptimePercentage'>{t.uptimeDisplay.percentLine(uptime.uptimePercentage)}</span>
       </div>
       
       <div className='uptimeTimeline'>
@@ -19,15 +22,15 @@ export default function UptimeDisplay({ uptime }: Readonly<Props>) {
             <div className={`uptimeDot uptimeDot-${day.status}`} />
             <div className='uptimeTooltip'>
               <div>{day.date}</div>
-              <div>{((day.actual / Math.max(day.expected, 1)) * 100).toFixed(1)}% oppetid</div>
+              <div>{t.uptimeDisplay.percentLine((day.actual / Math.max(day.expected, 1)) * 100)}</div>
             </div>
           </div>
         ))}
       </div>
       
       <div className='uptimeFooter'>
-        <span>For 30 dager siden</span>
-        <span>I dag</span>
+        <span>{t.uptimeDisplay.footerStart}</span>
+        <span>{t.uptimeDisplay.footerEnd}</span>
       </div>
     </div>
   )

--- a/client/src/locales/en.ts
+++ b/client/src/locales/en.ts
@@ -36,6 +36,11 @@ export const language = {
     estimated: 'Estimated',
     hourEstimate: (n: number) => `${n} hour${n === 1 ? '' : 's'}`,
   },
+  uptimeDisplay: {
+    percentLine: (pct: number) => `${pct.toFixed(1)}% uptime`,
+    footerStart: '30 days ago',
+    footerEnd: 'Today',
+  },
   exitModal: {
     line1: 'Are you sure you want to remove',
     line2: 'from the queue?',

--- a/client/src/locales/nb.ts
+++ b/client/src/locales/nb.ts
@@ -38,6 +38,11 @@ export const language: Language = {
     estimated: 'Estimert',
     hourEstimate: (n: number) => `${n} time${n === 1 ? '' : 'r'}`,
   },
+  uptimeDisplay: {
+    percentLine: (pct: number) => `${pct.toFixed(1)}% oppetid`,
+    footerStart: 'For 30 dager siden',
+    footerEnd: 'I dag',
+  },
   exitModal: {
     line1: 'Er du sikker på at du vil trekke',
     line2: 'fra køen?',

--- a/client/src/locales/nl.ts
+++ b/client/src/locales/nl.ts
@@ -38,6 +38,11 @@ export const language: Language = {
     estimated: 'Geschat',
     hourEstimate: (n: number) => `${n} uur${n === 1 ? '' : 'en'}`,
   },
+  uptimeDisplay: {
+    percentLine: (pct: number) => `${pct.toFixed(1)}% uptime`,
+    footerStart: '30 dagen geleden',
+    footerEnd: 'Vandaag',
+  },
   exitModal: {
     line1: 'Weet je zeker dat je',
     line2: 'uit de wachtrij wilt halen?',

--- a/server/uptimeService.ts
+++ b/server/uptimeService.ts
@@ -97,12 +97,24 @@ export function getUptimeSummary(now = nowMs()): UptimeSummary {
     const dayEnd = dayStart + DAY_MS
     const date = asUtcDate(dayStart)
 
-    const expected = offset === 0 ? new Date(now).getUTCHours() + 1 : 24
-
     let actual = 0
+    let minLogInDay: number | undefined
     for (const log of slotToTimestamp.values()) {
-      if (log >= dayStart && log < dayEnd) actual++
+      if (log >= dayStart && log < dayEnd) {
+        actual++
+        if (minLogInDay === undefined || log < minLogInDay) minLogInDay = log
+      }
     }
+
+    let expected: number
+    if (offset === 0) {
+      const slotsThroughNow = Math.floor((now - dayStart) / HOUR_MS) + 1
+      const trimStart = minLogInDay !== undefined ? Math.floor((minLogInDay - dayStart) / HOUR_MS) : 0
+      expected = Math.max(1, Math.min(24, slotsThroughNow - trimStart))
+    } else {
+      expected = 24
+    }
+
     if (actual > expected) actual = expected
 
     const status: UptimeDayStatus = actual === 0 ? 'red' : actual === expected ? 'green' : 'yellow'


### PR DESCRIPTION
## Summary
- **i18n:** `UptimeDisplay` uses `useLanguage()` and new `uptimeDisplay` strings in English, Norwegian, and Dutch (header/tooltip percentage line and timeline footer labels).
- **Today's expected count:** For the current UTC day, `expected` is the number of hour slots from the first hour that contains a log through the current hour (clamped 1–24), instead of always counting from UTC midnight. This matches hourly heartbeats that start when the server process starts, so today's percentage is not artificially low until late in the day.
<img width="1120" height="726" alt="Screenshot 2026-04-13 at 22 58 24" src="https://github.com/user-attachments/assets/4c520416-37dd-4eb1-bc0a-a5792cd93232" />

## Tradeoff
If the service is silent for many hours and then logs again, the window shortens from the first log in that UTC day, so a long outage followed by recovery can look better than a strict "since midnight" SLO. A future improvement would be an explicit monitoring-start timestamp in storage if you need that stricter model.